### PR TITLE
FIX Crash when postData is Empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,9 @@ function createJWTFromReq(req, key) {
   return new Promise(function(resolve, reject) {
     req.pipe(
       concat(function(post_data) {
+        if(!post_data || post_data.length === 0) {
+          return resolve({});
+        }
         resolve(JSON.parse(post_data));
       })
     );


### PR DESCRIPTION
Issue: Crash when In the POST Request, there is no Post Data/Body

Actual: 
It crashes the server when BODY is empty and the server is fully down.
![Screenshot 2022-02-25 at 14 52 03](https://user-images.githubusercontent.com/602127/155726710-97d7897b-43d2-47aa-847e-9bb278221d00.png)


Expected: Even the post body is empty, the server should return "payload is required"

This PR fixes that issue 😊

Please review and Approve/Merge